### PR TITLE
Fix efficiency bug in MemMappedDynamicDirectedGraphConverter. 

### DIFF
--- a/src/main/scala/co/teapot/tempest/graph/MemMappedDynamicDirectedGraphConverter.scala
+++ b/src/main/scala/co/teapot/tempest/graph/MemMappedDynamicDirectedGraphConverter.scala
@@ -48,6 +48,8 @@ object MemMappedDynamicDirectedGraphConverter {
     Util.logWithRunningTime(log, "first pass", printAtStart = true) {
       FileUtil.forEachIntPair(edgeListFile, log, linesPerMessage = 1000000) { (id1, id2) =>
         if (id1 >= outDegrees.size) {
+          // Note: addAll internally doubles the array capacity whenever the current capacity is reached, so
+          // the addAll calls in this loop in total cost O(maxNodeId) time and space.
           outDegrees.addAll(IntArrayList.wrap(new Array[Int](id1 + 1 - outDegrees.size)))
         }
         if (id2 >= inDegrees.size) {

--- a/src/main/scala/co/teapot/tempest/io/FileUtil.scala
+++ b/src/main/scala/co/teapot/tempest/io/FileUtil.scala
@@ -53,6 +53,20 @@ object FileUtil {
     }
   }
 
+  def forEachIntPair(intPairFile: File, log: String => Unit, logProgress: Boolean = true, linesPerMessage: Int = 1000000)
+                     (f: (Int, Int) => Unit): Unit = {
+    val linePattern = Pattern.compile(raw"(\d+)\s+(\d+)")
+    foreachLine(intPairFile, log, logProgress, linesPerMessage) { line =>
+      val matcher = linePattern.matcher(line)
+      if (!matcher.matches()) {
+        log("invalid line: " + line)
+      } else {
+        val u = matcher.group(1).toInt // Groups are 1-indexed
+        val v = matcher.group(2).toInt
+        f(u, v)
+      }
+    }
+  }
   /** Iterates over nonempty lines in the given file, optionally logging progress periodically using the
     * given log function.
     */


### PR DESCRIPTION
And for simplicity, drop support for graphs with between 2**31 and 2**32 edges for now.

@gkk-stripe could you review this?  This is a bug @atausz-stripe found in Tempest, where if the edge ids happen to be sorted (and the id range for targetIds is much smaller than the id range for sourceIds), the BigArrayLists in MemMappedDynamicDirectedGraphConverter which store degrees grow one entry at a time for O(n^2) total time (instead of doubling capacity as needed, for O(n) total time). I think this was introduced when I tried to add support for for than 2**31 nodes, but we don't currently need that, so for now I dropped support for converting such graphs.  We can add support for that back as needed.

CC @teapot-co/tempest 