### PR TITLE
Allow arbitrary node ids.

### DIFF
--- a/example/users.csv
+++ b/example/users.csv
@@ -2,3 +2,4 @@ Alice Johnson,alice,5,false
 "Bob Smith, Jr.",bob,2,false
 "Carol \"ninja\" Coder",carol,3,true
 ,nameless,0,false
+sneaky,"; DROP TABLE user;",0,true


### PR DESCRIPTION
Before this patch, nodeIds were allowed to be just alphanumeric
identifiers. This way a simple way of preventing SQL injection attacks.
This patch introduces use of SQL prepared statements to allow arbirtrary
node ids safely.

In most places, I rely on Anorm's (Scala's sql lib) for taking care of
preparing the prepared statement out of a template. However, in one place
the code relies on low-level JDBC so I had to craft the query myself.

SQL prepared statements do not have a good support for parameters with
collection as a value that show up in queries with `IN` clause.
Every element in `IN` requires a separate parameter and makes the query
grow in size. I capped number of ids passed in single query to 10k to limit
the size of queries we send to postgres.

This patch also adds a sample user to users.csv file that has an id that
looks like SQL injection attempt. I verify that this id is properly
resolved in tests.