### PR TITLE
Pointer, Offset and ByteCount abstractions in mmalloc

### DIFF
--- a/src/main/scala/co/teapot/mmalloc/LargeBlock.scala
+++ b/src/main/scala/co/teapot/mmalloc/LargeBlock.scala
@@ -18,26 +18,26 @@ package co.teapot.mmalloc
   * the remaining blocks in the Large Block have no headers.*/
 private[mmalloc] object LargeBlock {
   // Header Layout
-  val BlockTypeOffset = 0
-  val BlockCountOffset = 8
+  val BlockTypeOffset = Offset(0)
+  val BlockCountOffset = Offset(8)
   // Skip 4 bytes for alignment
-  val HeaderSize = 16
+  val HeaderSize = ByteCount(16)
 
   /** A random number, to sanity check block locations. */
   val LargeBlockMagicNumber = 1648927401674812135L
   val FreeBlockMagicNumber = -3040736377681742059L
 
-  def isLargeBlock(pointer: Long, data: LargeMappedByteBuffer): Boolean =
+  def isLargeBlock(pointer: Pointer, data: LargeMappedByteBuffer): Boolean =
     data.getLong(pointer + BlockTypeOffset) == LargeBlockMagicNumber
 
-  def isFreeBlock(pointer: Long, data: LargeMappedByteBuffer): Boolean =
+  def isFreeBlock(pointer: Pointer, data: LargeMappedByteBuffer): Boolean =
     data.getLong(pointer + BlockTypeOffset) == FreeBlockMagicNumber
 
   /** The number of blocks in this LargeBlock, including this one. */
-  def blockCount(pointer: Long, data: LargeMappedByteBuffer): Int =
+  def blockCount(pointer: Pointer, data: LargeMappedByteBuffer): Int =
     data.getInt(pointer + BlockCountOffset)
 
-  def initializeLargeBlock(pointer: Long, data: LargeMappedByteBuffer, blockCount: Int): Unit = {
+  def initializeLargeBlock(pointer: Pointer, data: LargeMappedByteBuffer, blockCount: Int): Unit = {
     data.putLong(pointer + BlockTypeOffset, LargeBlockMagicNumber)
     data.putInt(pointer + BlockCountOffset, blockCount)
   }

--- a/src/main/scala/co/teapot/mmalloc/LargeMappedByteBuffer.scala
+++ b/src/main/scala/co/teapot/mmalloc/LargeMappedByteBuffer.scala
@@ -83,7 +83,7 @@ class MMapByteBuffer(f: File) extends LargeMappedByteBuffer {
   override def getInt(index: Pointer): Int = memory.getInt(index.raw)
 
   def putInt(index: Pointer, v: Int, forceToDisk: Boolean = false): Unit = {
-    ensureSize(index + Offset(3))
+    ensureSize(index + Offset.bytes(3))
     memory.putInt(index.raw, v)
     if (forceToDisk)
       buffer.sync(index.raw, 4)
@@ -93,7 +93,7 @@ class MMapByteBuffer(f: File) extends LargeMappedByteBuffer {
   def getPointer(index: Pointer): Pointer = Pointer(getLong(index))
 
   def putLong(index: Pointer, v: Long, forceToDisk: Boolean = false): Unit = {
-    ensureSize(index + Offset(7))
+    ensureSize(index + Offset.bytes(7))
     memory.putLong(index.raw, v)
     if (forceToDisk)
       buffer.sync(index.raw, 8)

--- a/src/main/scala/co/teapot/mmalloc/LargeMappedByteBuffer.scala
+++ b/src/main/scala/co/teapot/mmalloc/LargeMappedByteBuffer.scala
@@ -25,24 +25,24 @@ import com.indeed.util.mmap.{DirectMemory, MMapBuffer}
   * extends the length of the underlying file.
   */
 trait LargeMappedByteBuffer {
-  def getInt(index: Long): Int
-  def putInt(index: Long, v: Int, forceToDisk: Boolean = false): Unit
+  def getInt(index: Pointer): Int
+  def putInt(index: Pointer, v: Int, forceToDisk: Boolean = false): Unit
 
-  def getLong(index: Long): Long
-  def putLong(index: Long, v: Long, forceToDisk: Boolean = false): Unit
+  def getLong(index: Pointer): Long
+  def putLong(index: Pointer, v: Long, forceToDisk: Boolean = false): Unit
 
-  def intSeq(start: Long, len: Int): IndexedSeq[Int] = new IndexedSeq[Int]() {
-    def apply(i: Int): Int = getInt(start + 4 * i)
+  def intSeq(start: Pointer, len: Int): IndexedSeq[Int] = new IndexedSeq[Int]() {
+    def apply(i: Int): Int = getInt(start + Offset.ints(i))
     def length: Int = len
   }
 
-  def longSeq(start: Long, len: Int): IndexedSeq[Long] = new IndexedSeq[Long]() {
-    def apply(i: Int): Long = getLong(start + 8 * i)
+  def longSeq(start: Pointer, len: Int): IndexedSeq[Long] = new IndexedSeq[Long]() {
+    def apply(i: Int): Long = getLong(start + Offset.longs(i))
     def length: Int = len
   }
 
   /** Copies byteCount bytes from srcIndex to destIndex in this buffer.  */
-  def copy(destIndex: Long, srcIndex: Long, byteCount: Long): Unit
+  def copy(destIndex: Pointer, srcIndex: Pointer, byteCount: ByteCount): Unit
 
   /** Loads the underlying memory mapped file into physical RAM.
     */
@@ -50,7 +50,7 @@ trait LargeMappedByteBuffer {
 
   /** Syncs count bytes at the given index to disk and blocks until that completes.
     */
-  def syncToDisk(startIndex: Long, count: Long): Unit
+  def syncToDisk(startIndex: Pointer, count: ByteCount): Unit
 
   /** Syncs all buffers to disk and blocks until that completes (see MappedByteBuffer.force()).
     */
@@ -70,9 +70,9 @@ class MMapByteBuffer(f: File) extends LargeMappedByteBuffer {
   val MinExpansionFactor = 1.1 // To prevent many tiny resizes, always resize by at least this factor.
 
   /** Makes sure that the given index is a valid offset by remapping if needed. */
-  def ensureSize(i: Long): Unit = {
-    if (i >= memory.length) {
-      val newSize = Util.divideRoundingUp(math.max(i + 1, (memory.length * MinExpansionFactor).toLong), ChunkSize) * ChunkSize
+  def ensureSize(i: Pointer): Unit = {
+    if (i.raw >= memory.length) {
+      val newSize = Util.divideRoundingUp(math.max(i.raw + 1, (memory.length * MinExpansionFactor).toLong), ChunkSize) * ChunkSize
       println(s"Resizing file from ${memory.length} to $newSize bytes") // TODO: Remove println
       buffer.close()
       buffer = new MMapBuffer(f, 0, newSize, FileChannel.MapMode.READ_WRITE, ByteOrder.nativeOrder())
@@ -80,27 +80,31 @@ class MMapByteBuffer(f: File) extends LargeMappedByteBuffer {
     }
   }
 
-  def getInt(index: Long): Int = memory.getInt(index)
-  def putInt(index: Long, v: Int, forceToDisk: Boolean = false): Unit = {
-    ensureSize(index + 3)
-    memory.putInt(index, v)
+  override def getInt(index: Pointer): Int = memory.getInt(index.raw)
+
+  def putInt(index: Pointer, v: Int, forceToDisk: Boolean = false): Unit = {
+    ensureSize(index + Offset(3))
+    memory.putInt(index.raw, v)
     if (forceToDisk)
-      buffer.sync(index, 4)
+      buffer.sync(index.raw, 4)
   }
 
+  override def getLong(index: Pointer): Long = memory.getLong(index.raw)
+  def getPointer(index: Pointer): Pointer = Pointer(getLong(index))
 
-  def getLong(index: Long): Long = memory.getLong(index)
-  def putLong(index: Long, v: Long, forceToDisk: Boolean = false): Unit = {
-    ensureSize(index + 7)
-    memory.putLong(index, v)
+  def putLong(index: Pointer, v: Long, forceToDisk: Boolean = false): Unit = {
+    ensureSize(index + Offset(7))
+    memory.putLong(index.raw, v)
     if (forceToDisk)
-      buffer.sync(index, 8)
+      buffer.sync(index.raw, 8)
   }
+  def putPointer(index: Pointer, v: Pointer, forceToDisk: Boolean = false): Unit =
+    putLong(index, v.raw, forceToDisk)
 
   /** Copies byteCount bytes from srcIndex to destIndex in this buffer.  */
-  def copy(destIndex: Long, srcIndex: Long, byteCount: Long): Unit = {
-    ensureSize(destIndex + byteCount)
-    memory.putBytes(destIndex, memory, srcIndex, byteCount)
+  def copy(destIndex: Pointer, srcIndex: Pointer, byteCount: ByteCount): Unit = {
+    ensureSize(destIndex + byteCount.toOffset)
+    memory.putBytes(destIndex.raw, memory, srcIndex.raw, byteCount.raw)
   }
 
   /** Loads the underlying memory mapped file into physical RAM.  Uses mlock.
@@ -111,13 +115,13 @@ class MMapByteBuffer(f: File) extends LargeMappedByteBuffer {
   /** Syncs the buffer containing the given indexes in the given range to disk and blocks until that completes (see
     * MappedByteBuffer.force()).
     */
-  def syncToDisk(startIndex: Long, count: Long): Unit = {
-    buffer.sync(startIndex, count)
+  override def syncToDisk(startIndex: Pointer, count: ByteCount): Unit = {
+    buffer.sync(startIndex.raw, count.raw)
   }
 
   /** Syncs all buffers to disk and blocks until that completes (see MappedByteBuffer.force()).
     */
-  def syncToDisk(): Unit = syncToDisk(0, memory.length())
+  def syncToDisk(): Unit = syncToDisk(Pointer(0), ByteCount(memory.length()))
 
   def close(): Unit = buffer.close()
 }

--- a/src/main/scala/co/teapot/mmalloc/PieceBlock.scala
+++ b/src/main/scala/co/teapot/mmalloc/PieceBlock.scala
@@ -19,15 +19,15 @@ import com.twitter.logging.Logger
 
 /** A PieceBlock is a block with a header, a bit-set indicating which pieces are free, and a sequence
   * of uniformly-sized pieces. */
-private[mmalloc] class PieceBlock(val pointer: Long, mmAllocator: MemoryMappedAllocator) {
+private[mmalloc] class PieceBlock(val pointer: Pointer, mmAllocator: MemoryMappedAllocator) {
   private def data = mmAllocator.data
   private def syncAllWrites = mmAllocator.syncAllWrites
 
   require(PieceBlock.isPieceBlock(pointer, mmAllocator.data), s"pointer $pointer points to a block " +
-    s"with magic number ${data.getLong(PieceBlock.BlockTypeOffset)}")
+    s"with magic number ${data.getLong(PieceBlock.BlockTypeOffset.toPointer)}")
 
   /** The number of bytes per piece. */
-  def pieceSize: Int = PieceBlock.pieceSize(pointer, data)
+  def pieceSize: ByteCount = PieceBlock.pieceSize(pointer, data)
 
   /** The number of free pieces in this block. */
   def freeCount: Int = PieceBlock.freeCount(pointer, data)
@@ -47,10 +47,10 @@ private[mmalloc] class PieceBlock(val pointer: Long, mmAllocator: MemoryMappedAl
     pieceCount,
     syncAllWrites)
 
-  private def firstPiecePointer: Long = pointer + PieceBlock.BitsetOffset + freeSet.sizeInBytes
+  private def firstPiecePointer: Pointer = pointer + PieceBlock.BitsetOffset + ByteCount(freeSet.sizeInBytes).toOffset
 
   /** Return a pointer to a location in the memory mapped file of size pieceSize bytes. */
-  def alloc(): Long = {
+  def alloc(): Pointer = {
     require(PieceBlock.freeCount(pointer, data) > 0, "alloc() called on full PieceBlock")
     val i = freeSet.nextSetBit(searchStart).getOrElse(
       throw new RuntimeException(s"alloc called on PieceBlock with freeCount $freeCount and empty free set"))
@@ -60,14 +60,15 @@ private[mmalloc] class PieceBlock(val pointer: Long, mmAllocator: MemoryMappedAl
     PieceBlock.setFreeCount(pointer, data, PieceBlock.freeCount(pointer, data) - 1, syncAllWrites)
     PieceBlock.log.trace(s"Allocated piece $i from PieceBlock($pointer); new freeCount $freeCount")
     logFreeSet()
-    firstPiecePointer + i * pieceSize
+    firstPiecePointer + Offset.fromBlocks(i, pieceSize)
   }
 
   /** Marks the piece starting at the given pointer as free. */
-  def free(piecePointer: Long): Unit = {
-    require((piecePointer - firstPiecePointer) % pieceSize == 0,
+  def free(piecePointer: Pointer): Unit = {
+    val pieceOffset = piecePointer - firstPiecePointer
+    require(pieceOffset.isStartOfBlock(pieceSize),
       "Pointer doesn't point to the start of a piece.")
-    val i = ((piecePointer - firstPiecePointer) / pieceSize).toInt
+    val i = pieceOffset.toBlockNumber(pieceSize)
     require(freeSet.get(i) == false, s"Attempt to free piece $i which is already free.  PieceBlock=$pointer  PiecePointer=$piecePointer")
     freeSet.set(i, true)
     PieceBlock.setFreeCount(pointer, data, freeCount + 1, syncAllWrites)
@@ -83,63 +84,66 @@ private[mmalloc] class PieceBlock(val pointer: Long, mmAllocator: MemoryMappedAl
 private[mmalloc] object PieceBlock {
   val log = Logger.get
   // Header layout
-  val BlockTypeOffset = 0
-  val PieceSizeOffset = 8
-  val PieceCountOffset = 12
-  val FreeCountOffset = 16
-  val SearchStartOffset = 20
-  val BitsetOffset = 24
+  val BlockTypeOffset = Offset(0)
+  val PieceSizeOffset = Offset(8)
+  val PieceCountOffset = Offset(12)
+  val FreeCountOffset = Offset(16)
+  val SearchStartOffset = Offset(20)
+  val BitsetOffset = Offset(24)
 
   /** A random number, to sanity check block locations. */
   val PieceBlockMagicNumber = -6662219058551629080L
 
-  def isPieceBlock(pointer: Long, data: LargeMappedByteBuffer): Boolean =
+  def isPieceBlock(pointer: Pointer, data: LargeMappedByteBuffer): Boolean =
     data.getLong(pointer + BlockTypeOffset) == PieceBlockMagicNumber
 
-  def pieceSize(pointer: Long, data: LargeMappedByteBuffer): Int =
-    data.getInt(pointer + PieceSizeOffset)
-  def setPieceSize(pointer: Long, data: LargeMappedByteBuffer, pieceSize: Int, syncWrite: Boolean): Unit = {
-    data.putInt(pointer + PieceSizeOffset, pieceSize, syncWrite)
+  def pieceSize(pointer: Pointer, data: LargeMappedByteBuffer): ByteCount =
+    ByteCount(data.getInt(pointer + PieceSizeOffset))
+  def setPieceSize(pointer: Pointer, data: LargeMappedByteBuffer, pieceSize: ByteCount, syncWrite: Boolean): Unit = {
+//    require(pointer.raw + PieceSizeOffset > 0, "Possible integer overflow found")
+    require(pieceSize.raw < Int.MaxValue, "Piece size has to fit into Integer type")
+    data.putInt(pointer + PieceSizeOffset, pieceSize.raw.toInt, syncWrite)
   }
 
-  def pieceCount(pointer: Long, data: LargeMappedByteBuffer): Int =
+  def pieceCount(pointer: Pointer, data: LargeMappedByteBuffer): Int =
     data.getInt(pointer + PieceCountOffset)
 
-  def freeCount(pointer: Long, data: LargeMappedByteBuffer): Int =
+  def freeCount(pointer: Pointer, data: LargeMappedByteBuffer): Int =
     data.getInt(pointer + FreeCountOffset)
-  def setFreeCount(pointer: Long, data: LargeMappedByteBuffer, freeCount: Int, syncWrite: Boolean): Unit = {
+  def setFreeCount(pointer: Pointer, data: LargeMappedByteBuffer, freeCount: Int, syncWrite: Boolean): Unit = {
     data.putInt(pointer + FreeCountOffset, freeCount, syncWrite)
   }
 
-  def isFull(pointer: Long, data: LargeMappedByteBuffer): Boolean =
+  def isFull(pointer: Pointer, data: LargeMappedByteBuffer): Boolean =
     freeCount(pointer, data) == 0
 
-  def searchStart(pointer: Long, data: LargeMappedByteBuffer): Int =
+  def searchStart(pointer: Pointer, data: LargeMappedByteBuffer): Int =
     data.getInt(pointer + PieceBlock.SearchStartOffset)
-  def setSearchStart(pointer: Long, data: LargeMappedByteBuffer, searchStart: Int): Unit = {
+  def setSearchStart(pointer: Pointer, data: LargeMappedByteBuffer, searchStart: Int): Unit = {
     // Don't need to sync, since searchStart is just an optimization hint
     data.putInt(pointer + PieceBlock.SearchStartOffset, searchStart)
   }
 
   def initializePieceBlock(
-      pointer: Long,
+      pointer: Pointer,
       data: LargeMappedByteBuffer,
-      pieceSize: Int,
-      blockSize: Int,
+      pieceSize: ByteCount,
+      blockSize: ByteCount,
       syncWrite: Boolean): Unit = {
     setPieceSize(pointer, data, pieceSize, false)
     // For each piece, we store an extra bit (1.0 / 8 bytes) to track if its free.  Hence
     // the number of pieces we can fit is the blockSize (excluding header and 4 bytes for rounding)
     // divided by the pieceSize + 1.0/8
-    val pieceCount = ((blockSize - PieceBlock.BitsetOffset - 4) / (pieceSize + 1.0 / 8)).toInt
+    val pieceCount = ((blockSize.raw - PieceBlock.BitsetOffset.raw - 4) / (pieceSize.raw + 1.0 / 8)).toInt
     data.putLong(pointer + BlockTypeOffset, PieceBlockMagicNumber)
-    data.putInt(pointer + PieceSizeOffset, pieceSize)
+    require(pieceSize.raw < Int.MaxValue)
+    data.putInt(pointer + PieceSizeOffset, pieceSize.raw.toInt)
     data.putInt(pointer + PieceCountOffset, pieceCount)
     data.putInt(pointer + FreeCountOffset, pieceCount)
     data.putInt(pointer + SearchStartOffset, 0)
     ByteBufferBasedBitSet.initializeWith1s(pointer + BitsetOffset, data, pieceCount)
     if (syncWrite) {
-      data.syncToDisk(pointer, BitsetOffset + pieceCount / 8)
+      data.syncToDisk(pointer, ByteCount(BitsetOffset.raw + pieceCount / 8))
     }
   }
 }

--- a/src/main/scala/co/teapot/tempest/graph/MemMappedDynamicDirectedGraph.scala
+++ b/src/main/scala/co/teapot/tempest/graph/MemMappedDynamicDirectedGraph.scala
@@ -16,7 +16,7 @@ package co.teapot.tempest.graph
 
 import java.io.File
 
-import co.teapot.mmalloc.MemoryMappedAllocator
+import co.teapot.mmalloc.{MemoryMappedAllocator, Offset}
 
 /**
   * A graph which stores edge data in a memory mapped file.  There is no object overhead per
@@ -47,8 +47,8 @@ class MemMappedDynamicDirectedGraph(file: File, syncAllWrites: Boolean = false) 
   mmAllocator.syncAllWrites = syncAllWrites
 
   private val edgeCountPointer = MemoryMappedAllocator.GlobalApplicationDataPointer
-  private val outGraphDataPointer = MemoryMappedAllocator.GlobalApplicationDataPointer + 8L
-  private val inGraphDataPointer = MemoryMappedAllocator.GlobalApplicationDataPointer + 16L
+  private val outGraphDataPointer = MemoryMappedAllocator.GlobalApplicationDataPointer + Offset(8L)
+  private val inGraphDataPointer = MemoryMappedAllocator.GlobalApplicationDataPointer + Offset(16L)
 
   private val outGraph = new MemMappedDynamicUnidirectionalGraph(mmAllocator, outGraphDataPointer, initializeNewGraph)
   private val inGraph = new MemMappedDynamicUnidirectionalGraph(mmAllocator, inGraphDataPointer, initializeNewGraph)
@@ -103,7 +103,7 @@ class MemMappedDynamicDirectedGraph(file: File, syncAllWrites: Boolean = false) 
   }
 
   /** Increases maxNodeId and creates neighborless nodes as needed to ensure the given id is a valid id. */
-  def ensureValidId(id: Long): Unit = {
+  def ensureValidId(id: Int): Unit = {
     outGraph.ensureValidId(id)
     inGraph.ensureValidId(id)
   }

--- a/src/test/scala/co/teapot/mmalloc/ByteBufferBasedBitSetSpec.scala
+++ b/src/test/scala/co/teapot/mmalloc/ByteBufferBasedBitSetSpec.scala
@@ -11,7 +11,7 @@ class ByteBufferBasedBitSetSpec extends FlatSpec with Matchers {
     val f = File.createTempFile("test", ".dat")
     f.deleteOnExit()
     val buffer = new MMapByteBuffer(f)
-    val pointer = 42 // Arbitrary
+    val pointer = Pointer(42) // Arbitrary
     val bitCount = 201
     ByteBufferBasedBitSet.initializeWith1s(pointer, buffer, bitCount)
     val s = new ByteBufferBasedBitSet(pointer, buffer, bitCount, false)
@@ -34,8 +34,8 @@ class ByteBufferBasedBitSetSpec extends FlatSpec with Matchers {
     f.deleteOnExit()
     val buffer = new MMapByteBuffer(f)
     val bitCounts = Seq(128, 125, 97, 96)
-    val pointer0 = 64 // Arbitrary
-    val pointer1 = 80 // Arbitrary
+    val pointer0 = Pointer(64) // Arbitrary
+    val pointer1 = Pointer(80) // Arbitrary
     for (bitCount <- bitCounts) {
       ByteBufferBasedBitSet.initializeWith0s(pointer0, buffer, bitCount)
       val s0 = new ByteBufferBasedBitSet(pointer0, buffer, bitCount, false)

--- a/src/test/scala/co/teapot/mmalloc/LargeMappedByteBufferSpec.scala
+++ b/src/test/scala/co/teapot/mmalloc/LargeMappedByteBufferSpec.scala
@@ -11,11 +11,12 @@ class LargeMappedByteBufferSpec extends FlatSpec with Matchers {
     val f = File.createTempFile("test", ".dat")
     f.deleteOnExit()
     val b = new MMapByteBuffer(f)
-    b.putInt(Pointer(1234 + (1L<< 30)), 42)
-    b.getInt(Pointer(1234 + (1L<< 30))) shouldEqual (42)
-    b.syncToDisk(1234 + (1L<< 30), 4)
+    val memLoc = Pointer(1234 + (1L << 30))
+    b.putInt(memLoc, 42)
+    b.getInt(memLoc) shouldEqual (42)
+    b.syncToDisk(memLoc, ByteCount(4))
     val b2 = new MMapByteBuffer(f)
-    b2.getInt(1234 + (1L<< 30)) shouldEqual (42)
+    b2.getInt(Pointer(1234 + (1L<< 30))) shouldEqual (42)
   }
 
   it should "support copying" in {
@@ -26,9 +27,9 @@ class LargeMappedByteBufferSpec extends FlatSpec with Matchers {
     val srcP = Pointer(4)
     b.putInt(srcP, 0x12345678)
     b.copy(Pointer(20), srcP, ByteCount(4))
-    b.getInt(20) should equal (0x12345678)
+    b.getInt(Pointer(20)) should equal (0x12345678)
     b.copy(Pointer(256), srcP, ByteCount(4))
-    b.getInt(256) should equal (0x12345678)
+    b.getInt(Pointer(256)) should equal (0x12345678)
 
     // Test multi-buffer copying
     val intCount = 456
@@ -51,12 +52,12 @@ class LargeMappedByteBufferSpec extends FlatSpec with Matchers {
 
     // try copying with start or dest on buffer boundaries
     b.copy(dest, Pointer(100), ByteCount(200))
-    b.getInt(dest) should equal (b.getInt(100))
+    b.getInt(dest) should equal (b.getInt(Pointer(100)))
     b.copy(start, Pointer(1000), ByteCount(200))
-    b.getInt(1000) should equal (b.getInt(start))
+    b.getInt(Pointer(1000)) should equal (b.getInt(start))
     b.copy(Pointer(1000), Pointer(100), ByteCount(200))
-    b.getInt(100) should equal(b.getInt(1000))
-    b.getInt(296) should equal(b.getInt(1196))
+    b.getInt(Pointer(100)) should equal(b.getInt(Pointer(1000)))
+    b.getInt(Pointer(296)) should equal(b.getInt(Pointer(1196)))
   }
 
   it should "support longSeq" in {

--- a/src/test/scala/co/teapot/mmalloc/LargeMappedByteBufferSpec.scala
+++ b/src/test/scala/co/teapot/mmalloc/LargeMappedByteBufferSpec.scala
@@ -11,8 +11,8 @@ class LargeMappedByteBufferSpec extends FlatSpec with Matchers {
     val f = File.createTempFile("test", ".dat")
     f.deleteOnExit()
     val b = new MMapByteBuffer(f)
-    b.putInt(1234 + (1L<< 30), 42)
-    b.getInt(1234 + (1L<< 30)) shouldEqual (42)
+    b.putInt(Pointer(1234 + (1L<< 30)), 42)
+    b.getInt(Pointer(1234 + (1L<< 30))) shouldEqual (42)
     b.syncToDisk(1234 + (1L<< 30), 4)
     val b2 = new MMapByteBuffer(f)
     b2.getInt(1234 + (1L<< 30)) shouldEqual (42)
@@ -23,37 +23,38 @@ class LargeMappedByteBufferSpec extends FlatSpec with Matchers {
     f.deleteOnExit()
     val b = new MMapByteBuffer(f)
     // Test copying within buffers
-    b.putInt(4, 0x12345678)
-    b.copy(20, 4, 4)
+    val srcP = Pointer(4)
+    b.putInt(srcP, 0x12345678)
+    b.copy(Pointer(20), srcP, ByteCount(4))
     b.getInt(20) should equal (0x12345678)
-    b.copy(256, 4, 4)
+    b.copy(Pointer(256), srcP, ByteCount(4))
     b.getInt(256) should equal (0x12345678)
 
     // Test multi-buffer copying
     val intCount = 456
-    val start = 16
-    val dest = 4128
+    val start = Pointer(16)
+    val dest = Pointer(4128)
     val values = Array.fill(intCount)(Random.self.nextInt())
 
     for ((v, i) <- values.zipWithIndex) {
-      b.putInt(start + 4 * i, v)
+      b.putInt(start + Offset.ints(i), v)
     }
-    b.copy(dest, start, 4 * intCount)
+    b.copy(dest, start, ByteCount(4 * intCount))
     b.intSeq(dest, intCount) should contain theSameElementsInOrderAs (values)
 
     // Make sure copying doesn't overwrite before or after the target
-    b.putInt(dest - 4, 0x76543210)
-    b.putInt(dest + 4 * intCount, 0x43211234)
-    b.copy(dest, start, 4 * intCount)
-    b.getInt(dest - 4) should equal (0x76543210)
-    b.getInt(dest + 4 * intCount) should equal (0x43211234)
+    b.putInt(dest - Offset(4), 0x76543210)
+    b.putInt(dest + Offset.ints(intCount), 0x43211234)
+    b.copy(dest, start, ByteCount(4 * intCount))
+    b.getInt(dest - Offset(4)) should equal (0x76543210)
+    b.getInt(dest + Offset.ints(intCount)) should equal (0x43211234)
 
     // try copying with start or dest on buffer boundaries
-    b.copy(dest, 100, 200)
+    b.copy(dest, Pointer(100), ByteCount(200))
     b.getInt(dest) should equal (b.getInt(100))
-    b.copy(start, 1000, 200)
+    b.copy(start, Pointer(1000), ByteCount(200))
     b.getInt(1000) should equal (b.getInt(start))
-    b.copy(1000, 100, 200)
+    b.copy(Pointer(1000), Pointer(100), ByteCount(200))
     b.getInt(100) should equal(b.getInt(1000))
     b.getInt(296) should equal(b.getInt(1196))
   }
@@ -64,13 +65,13 @@ class LargeMappedByteBufferSpec extends FlatSpec with Matchers {
     val b = new MMapByteBuffer(f)
 
     // Test Long Seq
-    val start = 240L
-    val dest = 16L
+    val start = Pointer(240L)
+    val dest = Pointer(16L)
     val longs = Array.fill(20)(Random.self.nextLong())
     for ((v, i) <- longs.zipWithIndex) {
-      b.putLong(start + 8 * i, v)
+      b.putLong(start + Offset.longs(i), v)
     }
-    b.copy(dest, start, 8 * longs.size)
+    b.copy(dest, start, ByteCount(8 * longs.size))
     b.longSeq(dest, longs.size) should contain theSameElementsInOrderAs (longs)
   }
 }

--- a/src/test/scala/co/teapot/mmalloc/MemoryMappedAllocatorSpec.scala
+++ b/src/test/scala/co/teapot/mmalloc/MemoryMappedAllocatorSpec.scala
@@ -10,60 +10,61 @@ class MemoryMappedAllocatorSpec extends FlatSpec with Matchers {
   "A MemoryMappedAllocator" should "allocate pieces correctly" in {
     val f = File.createTempFile("foo", ".dat")
     f.deleteOnExit()
-    val pieceSizes = Array(100, 200)
-    val blockSize = 232
+    val pieceSizes = Array(ByteCount(100), ByteCount(200))
+    val blockSize = ByteCount(232)
     val a = new MemoryMappedAllocator(f, pieceSizes, blockSize)
     // With header, a piece size block should have space for two pieces
-    val p1 = a.alloc(100)
-    val p2 = a.alloc(100)
+    val p1 = a.alloc(ByteCount(100))
+    val p2 = a.alloc(ByteCount(100))
     a.allocatedBlockCount should equal (1)
 
     // Make sure allocator re-uses pieces after they're freed
     a.free(p1)
-    val p3 = a.alloc(100)
+    val p3 = a.alloc(ByteCount(100))
     p3 should equal (p1)
     a.free(p2)
-    val p4 = a.alloc(100)
+    val p4 = a.alloc(ByteCount(100))
     p4 should equal (p2)
     a.allocatedBlockCount should equal (1)
 
     // Check that allocator creates a new piece block when needed
-    a.alloc(100)
+    a.alloc(ByteCount(100))
     a.allocatedBlockCount should equal (2)
-    a.alloc(101) // Should cause a pieceBlock for size 200 pieces to be created
+    a.alloc(ByteCount(101)) // Should cause a pieceBlock for size 200 pieces to be created
     a.allocatedBlockCount should equal (3)
 
     // Make sure that allocator goes back to the first block when the 2nd block fills
     a.free(p2)
-    a.alloc(100)
-    val p8 = a.alloc(100)
+    a.alloc(ByteCount(100))
+    val p8 = a.alloc(ByteCount(100))
     p8 should equal (p2)
 
     a.free(p8)
     // Make sure the file can be reopened by a new allocator instance
     val a2 = new MemoryMappedAllocator(f, pieceSizes, blockSize)
-    val p9 = a2.alloc(100)
+    val p9 = a2.alloc(ByteCount(100))
     p9 should equal (p2)
   }
 
   "A MemoryMappedAllocator" should "allocate large blocks correctly" in {
     val f = File.createTempFile("foo", ".dat")
     f.deleteOnExit()
-    val a = new MemoryMappedAllocator(f, pieceSizes = Array(100, 200), blockSize = 232)
-    val p1 = a.alloc(400) // 2 blocks
+    val a = new MemoryMappedAllocator(f, pieceSizes = Array(ByteCount(100), ByteCount(200)),
+      blockSize = ByteCount(232))
+    val p1 = a.alloc(ByteCount(400)) // 2 blocks
     a.allocatedBlockCount should equal(2)
     // Write arbitrary data at p1 to make sure p1 is past the header
     a.data.putLong(p1, 0x1234567812345678L)
-    a.data.putLong(p1 + 8, 0x1234567812345678L)
+    a.data.putLong(p1 + Offset(8), 0x1234567812345678L)
 
-    val p2 = a.alloc(600) // 3 blocks
+    val p2 = a.alloc(ByteCount(600)) // 3 blocks
     a.allocatedBlockCount should equal(5)
-    assert((p2 - p1) >= 400)
+    assert((p2 - p1).raw >= 400)
 
     // Make sure the freed blocks can be used for pieces.
     a.free(p1) // frees two blocks
-    a.alloc(100)
-    a.alloc(200)
+    a.alloc(ByteCount(100))
+    a.alloc(ByteCount(200))
     a.allocatedBlockCount should equal (5)
   }
 }


### PR DESCRIPTION
Introudce Pointer, Offset and ByteCount abstractions to mmalloc
implementation and its APIs. The motivation is the not use naked Ints
and Longs for distinct concepts like capacity, memory offset or memory
pointer. By introducing wrapper classes, we can track these things more
explicitly and separately.

The direct motivation for this change was an integer overflow bug that
was caused by mixing Ints and Longs in an expression that was computing
a pointer based of an offset.

This commit fixes two integer overflow bugs that I found.